### PR TITLE
restore bedrock agent runtime client

### DIFF
--- a/python/devopsbot.py
+++ b/python/devopsbot.py
@@ -64,10 +64,16 @@ Assistant should always provide a Confluence citation link when providing inform
 
 
 # Function to retrieve info from RAG with knowledge base
-def ask_bedrock_llm_with_knowledge_base(flat_conversation, knowledge_base_id, bedrock_client) -> str:
+def ask_bedrock_llm_with_knowledge_base(flat_conversation, knowledge_base_id) -> str:
+    
+    # Create a Bedrock agent runtime client
+    bedrock_agent_runtime_client = boto3.client(
+        "bedrock-agent-runtime", 
+        region_name=model_region_name
+    )
     
     # uses embedding model to retrieve and generate a response
-    response = bedrock_client.retrieve(
+    response = bedrock_agent_runtime_client.retrieve(
         retrievalQuery={
           'text': flat_conversation
         },
@@ -617,7 +623,7 @@ def handle_message_event(client, body, say, bedrock_client, app, token, register
             print(f"🚀 Flat conversation: {flat_conversation}")
         
         # Get context data from the knowledge base
-        knowledge_base_response = ask_bedrock_llm_with_knowledge_base(flat_conversation, ConfluenceKnowledgeBaseId, bedrock_client)
+        knowledge_base_response = ask_bedrock_llm_with_knowledge_base(flat_conversation, ConfluenceKnowledgeBaseId)
         
         if os.environ.get("VERA_DEBUG", "False") == "True":
             print(f"🚀 Knowledge base response: {knowledge_base_response}")


### PR DESCRIPTION
This pull request includes changes to the `python/devopsbot.py` file to update the Bedrock client usage and improve the function `ask_bedrock_llm_with_knowledge_base`. The most important changes include creating a new Bedrock agent runtime client and removing the `bedrock_client` parameter from the function.

Updates to Bedrock client usage:

* [`python/devopsbot.py`](diffhunk://#diff-e3360074a956da9b28e8ee515af6e9925f57733222828749e5498c0eb81f867bL67-R76): Modified the `ask_bedrock_llm_with_knowledge_base` function to create a Bedrock agent runtime client using `boto3.client` and removed the `bedrock_client` parameter from the function signature.

Function parameter updates:

* [`python/devopsbot.py`](diffhunk://#diff-e3360074a956da9b28e8ee515af6e9925f57733222828749e5498c0eb81f867bL620-R626): Updated the call to `ask_bedrock_llm_with_knowledge_base` in the `handle_message_event` function to remove the `bedrock_client` parameter.