### PR TITLE
Teach time and anthropic 3.7

### DIFF
--- a/terraform/lambda/lambda.tf
+++ b/terraform/lambda/lambda.tf
@@ -85,11 +85,25 @@ resource "aws_iam_role_policy" "DevOpsBotSlack_Bedrock" {
     {
       "Version" : "2012-10-17",
       "Statement" : [
-        # Grant permission to invoke bedrock models of any type in us-west-2 region
+        # Grant permission to invoke bedrock models of any type in US regions
         {
           "Effect" : "Allow",
-          "Action" : "bedrock:InvokeModel",
-          "Resource" : "arn:aws:bedrock:us-west-2::foundation-model/*"
+          "Action" : [
+            "bedrock:InvokeModel",
+            "bedrock:InvokeModelStream",
+            "bedrock:InvokeModelWithResponseStream",
+          ],
+          # Both no longer specify region, since Bedrock wants cross-region access
+          "Resource" : [
+            "arn:aws:bedrock:us-east-1::foundation-model/*",
+            "arn:aws:bedrock:us-east-2::foundation-model/*",
+            "arn:aws:bedrock:us-west-1::foundation-model/*",
+            "arn:aws:bedrock:us-west-2::foundation-model/*",
+            "arn:aws:bedrock:us-east-1:${data.aws_caller_identity.current.account_id}:inference-profile/*",
+            "arn:aws:bedrock:us-east-2:${data.aws_caller_identity.current.account_id}:inference-profile/*",
+            "arn:aws:bedrock:us-west-1:${data.aws_caller_identity.current.account_id}:inference-profile/*",
+            "arn:aws:bedrock:us-west-2:${data.aws_caller_identity.current.account_id}:inference-profile/*",
+          ]
         },
         # Grant permission to invoke bedrock guardrails of any type in us-west-2 region
         {


### PR DESCRIPTION
# Human notes
* Update to Anthropic Sonnet v3.7 w/ inference profiles. Basically, this is required for this model by AWS, and lets AWS use whatever region that's cheapest for them
* Updated terraform IAM role to permit inference profiles and invocations of model across different US regions. If you're outside the US, use your country's regions
* Teach the bot the time and date, called at each conversation invocation so it's right nearly to the second each time

# Bot notes
This pull request introduces several enhancements and updates to the `python/devopsbot.py` file to improve the bot's functionality and debugging capabilities. The most important changes include adding the current date and time, updating the bot's model and guidance, and incorporating debugging information.

### Enhancements and Updates:

* Added current date and time functionality:
  * Imported `datetime` and `timezone` modules.
  * Fetched and formatted current UTC date and time at launch.

* Updated bot information and model guidance:
  * Introduced `bot_name` and updated `model_guidance` to include the bot's name and current date and time.
  * Adjusted `model_id` to use the latest version of the US regional Claude model. [[1]](diffhunk://#diff-e3360074a956da9b28e8ee515af6e9925f57733222828749e5498c0eb81f867bR17-R54) [[2]](diffhunk://#diff-e3360074a956da9b28e8ee515af6e9925f57733222828749e5498c0eb81f867bL56-R80)

* Improved Slack response handling:
  * Added `slack_buffer_token_size` and `slack_message_size_limit_words` constants to manage response size.
  * Modified `response_on_slack` function to use `slack_buffer_token_size` for buffering and included debug information for response word and character counts. [[1]](diffhunk://#diff-e3360074a956da9b28e8ee515af6e9925f57733222828749e5498c0eb81f867bR17-R54) [[2]](diffhunk://#diff-e3360074a956da9b28e8ee515af6e9925f57733222828749e5498c0eb81f867bL303-R330) [[3]](diffhunk://#diff-e3360074a956da9b28e8ee515af6e9925f57733222828749e5498c0eb81f867bR343-R350)