### PR TITLE
Add guardrail tracing

### DIFF
--- a/terraform/lambda/lambda_receiver.tf
+++ b/terraform/lambda/lambda_receiver.tf
@@ -2,7 +2,7 @@
 # IAM Role and policies for Message Receiver Lambda
 ###
 
-data "aws_iam_policy_document" "Ue1TiDevOpsBotReceiverRole_assume_role" {
+data "aws_iam_policy_document" "DevOpsBotReceiverRole_assume_role" {
   statement {
     effect = "Allow"
     principals {
@@ -13,14 +13,14 @@ data "aws_iam_policy_document" "Ue1TiDevOpsBotReceiverRole_assume_role" {
   }
 }
 
-resource "aws_iam_role" "Ue1TiDevOpsBotReceiverRole" {
-  name               = "Ue1TiDevOpsBotReceiverRole"
-  assume_role_policy = data.aws_iam_policy_document.Ue1TiDevOpsBotReceiverRole_assume_role.json
+resource "aws_iam_role" "DevOpsBotReceiverRole" {
+  name               = "DevOpsBotReceiverRole"
+  assume_role_policy = data.aws_iam_policy_document.DevOpsBotReceiverRole_assume_role.json
 }
 
 resource "aws_iam_role_policy" "DevOpsBotReceiver_Lambda" {
   name = "InvokeLambda"
-  role = aws_iam_role.Ue1TiDevOpsBotReceiverRole.id
+  role = aws_iam_role.DevOpsBotReceiverRole.id
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -39,7 +39,7 @@ resource "aws_iam_role_policy" "DevOpsBotReceiver_Lambda" {
 
 resource "aws_iam_role_policy" "DevOpsBotReceiver_Cloudwatch" {
   name = "Cloudwatch"
-  role = aws_iam_role.Ue1TiDevOpsBotReceiverRole.id
+  role = aws_iam_role.DevOpsBotReceiverRole.id
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -76,7 +76,7 @@ data "archive_file" "devopsbot_receiver_lambda" {
 resource "aws_lambda_function" "devopsbot_receiver" {
   filename      = "${path.module}/receiver.zip"
   function_name = "DevOpsBotReceiver"
-  role          = aws_iam_role.Ue1TiDevOpsBotReceiverRole.arn
+  role          = aws_iam_role.DevOpsBotReceiverRole.arn
   handler       = "receiver.lambda_handler"
   timeout       = 10
   memory_size   = 128


### PR DESCRIPTION
# Human notes
* Add guardrail tracing option, surfaces why guardrail blocked things to the user in the slack response
* Fix system prompt injection

# Robot notes beep boop
This pull request introduces several updates to the `python/devopsbot.py` file to enhance functionality, improve error handling, and refine AI interaction. Additionally, there are changes to the Terraform configuration in `lambda_receiver.tf` to standardize IAM role naming. Below is a categorized summary of the most important changes.

### Enhancements to AI Interaction and Guardrails
* Introduced `guardrailTracing` to enable tracing options for guardrails (`enabled`, `enabled_full`, `disabled`) and included it in the AI request payload (`def ai_request`) to enhance security and debugging capabilities. [[1]](diffhunk://#diff-e3360074a956da9b28e8ee515af6e9925f57733222828749e5498c0eb81f867bR60-R68) [[2]](diffhunk://#diff-e3360074a956da9b28e8ee515af6e9925f57733222828749e5498c0eb81f867bR462)
* Replaced `model_guidance` with `system_prompt` and updated the initialization process to use `initial_model_system_prompt` for better clarity and maintainability. [[1]](diffhunk://#diff-e3360074a956da9b28e8ee515af6e9925f57733222828749e5498c0eb81f867bL90-R91) [[2]](diffhunk://#diff-e3360074a956da9b28e8ee515af6e9925f57733222828749e5498c0eb81f867bL828-R892)
* Enhanced Slack responses to include detailed guardrail blocking information, such as type, confidence, and filter strength, when content is flagged by Veradigm's content filter.

### Error Handling Improvements
* Added exception handling in `ask_bedrock_llm_with_knowledge_base` to catch and log errors, including specific handling for Aurora auto-pausing scenarios, with user-friendly Slack messages prompting retries. [[1]](diffhunk://#diff-e3360074a956da9b28e8ee515af6e9925f57733222828749e5498c0eb81f867bR219) [[2]](diffhunk://#diff-e3360074a956da9b28e8ee515af6e9925f57733222828749e5498c0eb81f867bL893-R965)
* Added debug logging for raw and structured knowledge base responses when `VERA_DEBUG` is enabled.

### Refactoring for Consistency
* Renamed `url` fields to `source` in knowledge base responses to better represent diverse data sources (e.g., Confluence, S3). Updated all related references in `rerank_text` and `handle_message_event`. [[1]](diffhunk://#diff-e3360074a956da9b28e8ee515af6e9925f57733222828749e5498c0eb81f867bR129-R141) [[2]](diffhunk://#diff-e3360074a956da9b28e8ee515af6e9925f57733222828749e5498c0eb81f867bL199-R201) [[3]](diffhunk://#diff-e3360074a956da9b28e8ee515af6e9925f57733222828749e5498c0eb81f867bL893-R965)
* Updated AI request conversation structure to append assistant responses instead of user responses for knowledge base citations. [[1]](diffhunk://#diff-e3360074a956da9b28e8ee515af6e9925f57733222828749e5498c0eb81f867bL925-R979) [[2]](diffhunk://#diff-e3360074a956da9b28e8ee515af6e9925f57733222828749e5498c0eb81f867bL940-R994)

### Terraform Configuration Updates
* Standardized IAM role naming in `lambda_receiver.tf` by renaming `Ue1TiDevOpsBotReceiverRole` to `DevOpsBotReceiverRole` across all related resources for improved clarity and consistency. [[1]](diffhunk://#diff-cb771e30fed3aa42ce485c551c5ef11c6d7ace3d2a6ac29ce05dda4f75cba637L5-R5) [[2]](diffhunk://#diff-cb771e30fed3aa42ce485c551c5ef11c6d7ace3d2a6ac29ce05dda4f75cba637L16-R23) [[3]](diffhunk://#diff-cb771e30fed3aa42ce485c551c5ef11c6d7ace3d2a6ac29ce05dda4f75cba637L42-R42) [[4]](diffhunk://#diff-cb771e30fed3aa42ce485c551c5ef11c6d7ace3d2a6ac29ce05dda4f75cba637L79-R79)

These changes collectively improve the bot's robustness, maintainability, and user experience while aligning infrastructure naming conventions.